### PR TITLE
Adding variables for initial clone of rsGit and rsCommon

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -5,7 +5,7 @@
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Force
 . "C:\DevOps\secrets.ps1"
 
-
+### if $d.gitBr and $d.commonBr are not defined, make them the same as $d.provBr
 if ( -not $d.gitBr)
 {
     $d.gitBr = $d.provBr
@@ -17,7 +17,7 @@ if ( -not $d.commonBr)
 
 ### Download and install git client
 (New-Object System.Net.webclient).DownloadFile("https://raw.githubusercontent.com/rsWinAutomationSupport/Git/v1.9.4/Git-Windows-Latest.exe","C:\DevOps\Git-Windows-Latest.exe")
-Start -Wait "C:\DevOps\Git-Windows-Latest.exe" -ArgumentList "/verysilent"
+Start-Process -Wait "C:\DevOps\Git-Windows-Latest.exe" -ArgumentList "/verysilent"
 
 ### Set Browser service to manual
 Set-Service Browser -StartupType Manual
@@ -31,31 +31,31 @@ Start-Service Browser
 #################################################
 ### Clone initial repo's to Modules directory ###
 #################################################
-cd "C:\Program Files\WindowsPowerShell\Modules"
+Set-Location "C:\Program Files\WindowsPowerShell\Modules"
 
 # 1 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.commonBr) https://github.com/rsWinAutomationSupport/rsCommon.git"
+Start-Process -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.commonBr) https://github.com/rsWinAutomationSupport/rsCommon.git"
 ###########################################
 
 # 2 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.gitBr) https://github.com/rsWinAutomationSupport/rsGit.git"
+Start-Process -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.gitBr) https://github.com/rsWinAutomationSupport/rsGit.git"
 ###########################################
 
 ##################################################
 ### Clone initial repos to C:\DevOps directory ###
 ##################################################
-cd "C:\DevOps"
+Set-Location "C:\DevOps"
 
 # 3 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.branch_rsConfigs) $((('https://', $d.git_Oauthtoken, '@github.com' -join ''), $($d.git_username), $($d.mR , '.git' -join '')) -join '/')"
+Start-Process -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.branch_rsConfigs) $((('https://', $d.git_Oauthtoken, '@github.com' -join ''), $($d.git_username), $($d.mR , '.git' -join '')) -join '/')"
 ###########################################
 
 # 4 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.provBr) https://github.com/rsWinAutomationSupport/rsProvisioning.git"
+Start-Process -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.provBr) https://github.com/rsWinAutomationSupport/rsProvisioning.git"
 ###########################################
 
 Stop-Service Browser

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -4,6 +4,18 @@
 
 Set-ExecutionPolicy -ExecutionPolicy Bypass -Force
 . "C:\DevOps\secrets.ps1"
+
+
+if ( -not $d.gitBr)
+{
+    $d.gitBr = $d.provBr
+}
+if ( -not $d.commonBr)
+{
+    $d.commonBr = $d.provBr
+}
+
+### Download and install git client
 (New-Object System.Net.webclient).DownloadFile("https://raw.githubusercontent.com/rsWinAutomationSupport/Git/v1.9.4/Git-Windows-Latest.exe","C:\DevOps\Git-Windows-Latest.exe")
 Start -Wait "C:\DevOps\Git-Windows-Latest.exe" -ArgumentList "/verysilent"
 
@@ -23,12 +35,12 @@ cd "C:\Program Files\WindowsPowerShell\Modules"
 
 # 1 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.provBr) https://github.com/rsWinAutomationSupport/rsCommon.git"
+Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.commonBr) https://github.com/rsWinAutomationSupport/rsCommon.git"
 ###########################################
 
 # 2 #
 ### [ Edit branch and git user in URI ] ###
-Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.provBr) https://github.com/rsWinAutomationSupport/rsGit.git"
+Start -Wait "C:\Program Files (x86)\Git\bin\git.exe" -ArgumentList "clone --branch $($d.gitBr) https://github.com/rsWinAutomationSupport/rsGit.git"
 ###########################################
 
 ##################################################


### PR DESCRIPTION
This change introduces two new variables into secrets.ps1 or more precisely interprets these variables if they are defined in the hashtable inside secrets.ps1. Those variables are:
- `$d.gitBr` - this is used for initial clone of rsGit
- `$d.commonBr` - this is used for initial clone of rsCommon

If either of those variables is not set inside secrets.ps1, they will be set to the value that `$d.provBr` is set to.

I have also done some minor style fixes, like replacing aliases (i.e. cd and start) with the respective cmdlets (i.e. Set-Location and Start-Process)

Edit: Forgot to mention, this fixes #3 
